### PR TITLE
convert cmd line argument for sample size from a string to an int

### DIFF
--- a/training/overlapped_speakers/prepare.py
+++ b/training/overlapped_speakers/prepare.py
@@ -23,7 +23,7 @@ CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 DATASET_VIDEO_PATH = sys.argv[1]
 DATASET_ALIGN_PATH = sys.argv[2]
 
-VAL_SAMPLES = sys.argv[3]
+VAL_SAMPLES = int(sys.argv[3])
 
 for speaker_path in glob.glob(os.path.join(DATASET_VIDEO_PATH, '*')):
     speaker_id = os.path.splitext(speaker_path)[0].split('/')[-1]


### PR DESCRIPTION
I found that running `prepare.py` was correctly splitting up the training set and the validation set.  This was caused by the number of samples (obtained from the command line arguments) being a string instead of a number.